### PR TITLE
Inject the button on turbo:load

### DIFF
--- a/src/gitServices/github/GitHubService.ts
+++ b/src/gitServices/github/GitHubService.ts
@@ -10,6 +10,8 @@ import { createPopper } from "@popperjs/core";
 import "./github.css";
 
 export class GitHubService implements GitService {
+    private static BUTTON_ID = "try-in-web-ide-btn";
+
     /**
      * @returns true if current page is a GitHub page to inject the button to
      */
@@ -19,6 +21,23 @@ export class GitHubService implements GitService {
     }
 
     public async injectButton() {
+        await this._injectButton();
+
+        // GitHub uses Turbo to load the project repo's `Code`, `Issues`, `Pull requests`,
+        // `Actions`, etc. pages. In case the user clicks from a non-Code page to the Code
+        // page, try to inject button.
+        document.addEventListener("turbo:load", () => {
+            if (GitHubService.matches()) {
+                this._injectButton();
+            }
+        });
+    }
+
+    private async _injectButton() {
+        if (document.getElementById(GitHubService.BUTTON_ID)) {
+            return;
+        }
+
         const actionBar = window.document.querySelector(".file-navigation");
         const project = getProjectURL();
         const endpoints = await getEndpoints();
@@ -40,6 +59,7 @@ export class GitHubService implements GitService {
         endpoint: Endpoint
     ) {
         const btnGroup = document.createElement("div");
+        btnGroup.id = GitHubService.BUTTON_ID;
         btnGroup.className = "gh-btn-group ml-2";
         const btn = window.document.createElement("a");
         btn.href = endpoint.url + "/#" + projectUrl;
@@ -63,6 +83,7 @@ export class GitHubService implements GitService {
     ) {
         const btnGroup = document.createElement("div");
         btnGroup.className = "gh-btn-group ml-2";
+        btnGroup.id = GitHubService.BUTTON_ID;
 
         const btn = document.createElement("a");
         btn.className = "gh-btn btn-primary";
@@ -80,7 +101,6 @@ export class GitHubService implements GitService {
         btnGroup.appendChild(dropdownBtn);
 
         const dropdownContent = document.createElement("ul");
-        dropdownContent.id = "def";
         dropdownContent.className = "gh-dropdown-menu";
 
         endpoints.forEach((e) => {


### PR DESCRIPTION
Github uses https://github.com/hotwired/turbo to load the view for `Code`, `Issues`, `Pull requests`, `Discussions`, etc.

<img width="690" alt="image" src="https://user-images.githubusercontent.com/83611742/218119370-35c49639-75f0-42da-86d6-107652d23664.png">

When turbo loads a new view, the extension's content script is not loaded again, therefore causing https://github.com/redhat-developer/try-in-web-ide-browser-extension/issues/13.


This PR listens to the `turbo:load` event and tries to inject the button if we are in the `Code` view:

https://user-images.githubusercontent.com/83611742/218120135-27ac3267-6e41-4d76-8471-ee422d4b38bd.mov
