### PR TITLE
Fix popperjs/core margin warning

### DIFF
--- a/package.json
+++ b/package.json
@@ -5,7 +5,6 @@
   "repository": "https://github.com/redhat-developer/try-in-web-ide-browser-extension",
   "license": "MIT",
   "devDependencies": {
-    "@popperjs/core": "^2.11.6",
     "@types/chrome": "^0.0.211",
     "@types/jest": "^29.4.0",
     "@types/node": "^18.11.18",
@@ -32,5 +31,8 @@
     "build:prod": "webpack --mode=production --node-env=production",
     "watch": "yarn build --watch",
     "test": "jest"
+  },
+  "dependencies": {
+    "@popperjs/core": "^2.11.6"
   }
 }

--- a/src/contentScript/buttonInjector/github/github.css
+++ b/src/contentScript/buttonInjector/github/github.css
@@ -82,7 +82,6 @@
     box-shadow: var(--color-shadow-large, 0 8px 24px rgba(140,149,159,0.2));
     left: 0;
     list-style: none;
-    margin-top: 2px;
     padding-bottom: var(--primer-control-small-paddingBlock, 4px);
     padding-top: var(--primer-control-small-paddingBlock, 4px);
     position: absolute;


### PR DESCRIPTION
Signed-off-by: David Kwon <dakwon@redhat.com>

There is a warning displayed in the console when the button is injected to a GitHub repo page:
<img width="884" alt="image" src="https://user-images.githubusercontent.com/83611742/218191586-a06f95ec-c3f5-46de-82bd-d37a2ee3983b.png">

As suggested by the warning, the `offset` modifier is already being used:
https://github.com/redhat-developer/try-in-web-ide-browser-extension/blob/2e8c1b356b745c092bc843c768485711dfa60fb0/src/gitServices/github/GitHubService.ts#L146-L148

This PR removes the unnecessary `margin` style that is causing the error.
The PR also moves the popperjs/core dependency from `devDependencies` to `dependencies` in `package.json`.