### PR TITLE
Display default endpoint at the top of dropdown menu

### DIFF
--- a/src/contentScript/buttonInjector/github/GitHubButtonInjector.ts
+++ b/src/contentScript/buttonInjector/github/GitHubButtonInjector.ts
@@ -103,6 +103,7 @@ export class GitHubButtonInjector implements ButtonInjector {
         const dropdownContent = document.createElement("ul");
         dropdownContent.className = "gh-dropdown-menu";
 
+        this.setActiveEndpointToFront(endpoints);
         endpoints.forEach((e) => {
             dropdownContent.appendChild(
                 this.createEndpiontListItem(projectUrl, e)
@@ -113,6 +114,15 @@ export class GitHubButtonInjector implements ButtonInjector {
         element.appendChild(btnGroup);
 
         this.setUpDropdown(dropdownBtn, dropdownContent);
+    }
+
+    private setActiveEndpointToFront(endpoints: Endpoint[]) {
+        const active = endpoints.find(e => e.active);
+        if (!active) {
+            throw new Error('No endpoint is selected in the extension options.')
+        }
+        endpoints.splice(endpoints.findIndex(e => e.active), 1);
+        endpoints.unshift(active);
     }
 
     private createEndpiontListItem(projectUrl: string, endpoint: Endpoint) {


### PR DESCRIPTION
Fixes https://github.com/redhat-developer/try-in-web-ide-browser-extension/issues/21

To test:

* Follow [steps](https://github.com/redhat-developer/try-in-web-ide-browser-extension#quick-start) to build and sideload extension
* In the extension options, add multiple new endpoints
![image](https://user-images.githubusercontent.com/83611742/219232921-ce7a6658-f247-48dc-946e-5d1ea4288fcb.png)
* The dropdown should display the selected (ie default) endpoint at the top:
![image](https://user-images.githubusercontent.com/83611742/219233113-f987bb3a-b12d-43d7-a937-da8a80506022.png)
